### PR TITLE
Make Markdown linguist detectable.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.md linguist-detectable


### PR DESCRIPTION
Before this change, project gets detected as 100% Gnuplot. After this
change, project gets detected as 90.4% Markdown 9.6% Gnuplot.

---

before this change | after this change
--- | ---
<img width="214" alt="Screen Shot 2021-09-22 at 20 25 46" src="https://user-images.githubusercontent.com/52637275/134401025-4914bf28-2c46-41d8-b438-cb5341556747.png"> | <img width="223" alt="Screen Shot 2021-09-22 at 20 25 35" src="https://user-images.githubusercontent.com/52637275/134401039-7760f5d4-3067-4a33-9741-5fbe4fd71d33.png">


